### PR TITLE
docs: remove final and metadata fields from docstring

### DIFF
--- a/src/a2a/utils/message.py
+++ b/src/a2a/utils/message.py
@@ -1,7 +1,6 @@
 """Utility functions for creating and handling A2A Message objects."""
 
 import uuid
-from typing import Any
 
 from a2a.types import (
     Message,
@@ -15,8 +14,6 @@ def new_agent_text_message(
     text: str,
     context_id: str | None = None,
     task_id: str | None = None,
-    final: bool | None = None,
-    metadata: dict[str, Any] | None = None,
 ) -> Message:
     """Creates a new agent message containing a single TextPart.
 
@@ -24,8 +21,6 @@ def new_agent_text_message(
         text: The text content of the message.
         context_id: The context ID for the message.
         task_id: The task ID for the message.
-        final: Optional boolean indicating if this is the final message.
-        metadata: Optional metadata for the message.
 
     Returns:
         A new `Message` object with role 'agent'.
@@ -36,8 +31,6 @@ def new_agent_text_message(
         messageId=str(uuid.uuid4()),
         taskId=task_id,
         contextId=context_id,
-        final=final,
-        metadata=metadata,
     )
 
 
@@ -45,8 +38,6 @@ def new_agent_parts_message(
     parts: list[Part],
     context_id: str | None = None,
     task_id: str | None = None,
-    final: bool | None = None,
-    metadata: dict[str, Any] | None = None,
 ):
     """Creates a new agent message containing a list of Parts.
 
@@ -66,8 +57,6 @@ def new_agent_parts_message(
         messageId=str(uuid.uuid4()),
         taskId=task_id,
         contextId=context_id,
-        final=final,
-        metadata=metadata,
     )
 
 

--- a/src/a2a/utils/message.py
+++ b/src/a2a/utils/message.py
@@ -1,6 +1,7 @@
 """Utility functions for creating and handling A2A Message objects."""
 
 import uuid
+from typing import Any
 
 from a2a.types import (
     Message,
@@ -14,6 +15,8 @@ def new_agent_text_message(
     text: str,
     context_id: str | None = None,
     task_id: str | None = None,
+    final: bool | None = None,
+    metadata: dict[str, Any] | None = None,
 ) -> Message:
     """Creates a new agent message containing a single TextPart.
 
@@ -33,6 +36,8 @@ def new_agent_text_message(
         messageId=str(uuid.uuid4()),
         taskId=task_id,
         contextId=context_id,
+        final=final,
+        metadata=metadata,
     )
 
 
@@ -40,6 +45,8 @@ def new_agent_parts_message(
     parts: list[Part],
     context_id: str | None = None,
     task_id: str | None = None,
+    final: bool | None = None,
+    metadata: dict[str, Any] | None = None,
 ):
     """Creates a new agent message containing a list of Parts.
 
@@ -59,6 +66,8 @@ def new_agent_parts_message(
         messageId=str(uuid.uuid4()),
         taskId=task_id,
         contextId=context_id,
+        final=final,
+        metadata=metadata,
     )
 
 

--- a/src/a2a/utils/message.py
+++ b/src/a2a/utils/message.py
@@ -45,8 +45,6 @@ def new_agent_parts_message(
         parts: The list of `Part` objects for the message content.
         context_id: The context ID for the message.
         task_id: The task ID for the message.
-        final: Optional boolean indicating if this is the final message.
-        metadata: Optional metadata for the message.
 
     Returns:
         A new `Message` object with role 'agent'.


### PR DESCRIPTION
# Description

This pull request adds two optional parameters - `final` and `metadata` - to the utility functions `new_agent_text_message` and `new_agent_parts_message`:

* **`final`** (`bool | None`): Indicates whether the message is the final one. Useful for managing control flow in streaming agent interactions.
* **`metadata`** (`dict[str, Any] | None`): Allows attaching additional information to a message, such as token counts, response time, or other relevant metrics, which is helpful for monitoring and debugging during development.

**NOTE:** These parameters were already documented but had not been included in the function signatures. This PR ensures that the implementation is aligned with the documentation and supports enhanced message handling for streaming agents.

---

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/google/a2a-python/blob/main/CONTRIBUTING.md).
- [x] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
- [x] Ensure the tests and linter pass (Run `nox -s format` from the repository root to format)
- [x] Appropriate docs were updated (if necessary)
