### PR TITLE
fix: remove error types from enqueable events

### DIFF
--- a/src/a2a/server/events/event_queue.py
+++ b/src/a2a/server/events/event_queue.py
@@ -3,8 +3,6 @@ import logging
 import sys
 
 from a2a.types import (
-    A2AError,
-    JSONRPCError,
     Message,
     Task,
     TaskArtifactUpdateEvent,
@@ -21,8 +19,6 @@ Event = (
     | Task
     | TaskStatusUpdateEvent
     | TaskArtifactUpdateEvent
-    | A2AError
-    | JSONRPCError
 )
 """Type alias for events that can be enqueued."""
 


### PR DESCRIPTION
Fixes https://github.com/google-a2a/a2a-python/issues/137 🦕
