### PR TITLE
fix(stream): don't block event loop in EventQueue

### DIFF
--- a/src/a2a/server/tasks/task_updater.py
+++ b/src/a2a/server/tasks/task_updater.py
@@ -34,7 +34,7 @@ class TaskUpdater:
         self.task_id = task_id
         self.context_id = context_id
 
-    def update_status(
+    async def update_status(
         self,
         state: TaskState,
         message: Message | None = None,
@@ -52,7 +52,7 @@ class TaskUpdater:
         current_timestamp = (
             timestamp if timestamp else datetime.now(timezone.utc).isoformat()
         )
-        self.event_queue.enqueue_event(
+        await self.event_queue.enqueue_event(
             TaskStatusUpdateEvent(
                 taskId=self.task_id,
                 contextId=self.context_id,
@@ -65,7 +65,7 @@ class TaskUpdater:
             )
         )
 
-    def add_artifact(
+    async def add_artifact(
         self,
         parts: list[Part],
         artifact_id: str = str(uuid.uuid4()),
@@ -82,7 +82,7 @@ class TaskUpdater:
             append: Optional boolean indicating if this chunk appends to a previous one.
             last_chunk: Optional boolean indicating if this is the last chunk.
         """
-        self.event_queue.enqueue_event(
+        await self.event_queue.enqueue_event(
             TaskArtifactUpdateEvent(
                 taskId=self.task_id,
                 contextId=self.context_id,
@@ -95,32 +95,32 @@ class TaskUpdater:
             )
         )
 
-    def complete(self, message: Message | None = None):
+    async def complete(self, message: Message | None = None):
         """Marks the task as completed and publishes a final status update."""
-        self.update_status(
+        await self.update_status(
             TaskState.completed,
             message=message,
             final=True,
         )
 
-    def failed(self, message: Message | None = None):
+    async def failed(self, message: Message | None = None):
         """Marks the task as failed and publishes a final status update."""
-        self.update_status(TaskState.failed, message=message, final=True)
+        await self.update_status(TaskState.failed, message=message, final=True)
 
-    def reject(self, message: Message | None = None):
+    async def reject(self, message: Message | None = None):
         """Marks the task as rejected and publishes a final status update."""
-        self.update_status(TaskState.rejected, message=message, final=True)
+        await self.update_status(TaskState.rejected, message=message, final=True)
 
-    def submit(self, message: Message | None = None):
+    async def submit(self, message: Message | None = None):
         """Marks the task as submitted and publishes a status update."""
-        self.update_status(
+        await self.update_status(
             TaskState.submitted,
             message=message,
         )
 
-    def start_work(self, message: Message | None = None):
+    async def start_work(self, message: Message | None = None):
         """Marks the task as working and publishes a status update."""
-        self.update_status(
+        await self.update_status(
             TaskState.working,
             message=message,
         )

--- a/tests/server/events/test_event_queue.py
+++ b/tests/server/events/test_event_queue.py
@@ -39,7 +39,7 @@ def event_queue() -> EventQueue:
 async def test_enqueue_and_dequeue_event(event_queue: EventQueue) -> None:
     """Test that an event can be enqueued and dequeued."""
     event = Message(**MESSAGE_PAYLOAD)
-    event_queue.enqueue_event(event)
+    await event_queue.enqueue_event(event)
     dequeued_event = await event_queue.dequeue_event()
     assert dequeued_event == event
 
@@ -48,7 +48,7 @@ async def test_enqueue_and_dequeue_event(event_queue: EventQueue) -> None:
 async def test_dequeue_event_no_wait(event_queue: EventQueue) -> None:
     """Test dequeue_event with no_wait=True."""
     event = Task(**MINIMAL_TASK)
-    event_queue.enqueue_event(event)
+    await event_queue.enqueue_event(event)
     dequeued_event = await event_queue.dequeue_event(no_wait=True)
     assert dequeued_event == event
 
@@ -71,7 +71,7 @@ async def test_dequeue_event_wait(event_queue: EventQueue) -> None:
         status=TaskStatus(state=TaskState.working),
         final=True,
     )
-    event_queue.enqueue_event(event)
+    await event_queue.enqueue_event(event)
     dequeued_event = await event_queue.dequeue_event()
     assert dequeued_event == event
 
@@ -84,7 +84,7 @@ async def test_task_done(event_queue: EventQueue) -> None:
         contextId='session-xyz',
         artifact=Artifact(artifactId='11', parts=[Part(TextPart(text='text'))]),
     )
-    event_queue.enqueue_event(event)
+    await event_queue.enqueue_event(event)
     _ = await event_queue.dequeue_event()
     event_queue.task_done()
 
@@ -99,6 +99,6 @@ async def test_enqueue_different_event_types(
         JSONRPCError(code=111, message='rpc error'),
     ]
     for event in events:
-        event_queue.enqueue_event(event)
+        await event_queue.enqueue_event(event)
         dequeued_event = await event_queue.dequeue_event()
         assert dequeued_event == event

--- a/tests/server/request_handlers/test_default_request_handler.py
+++ b/tests/server/request_handlers/test_default_request_handler.py
@@ -1,0 +1,77 @@
+import time
+
+import pytest
+
+from a2a.server.agent_execution import AgentExecutor, RequestContext
+from a2a.server.events import EventQueue
+from a2a.server.request_handlers import DefaultRequestHandler
+from a2a.server.tasks import InMemoryTaskStore, TaskUpdater
+from a2a.types import (
+    Message,
+    MessageSendParams,
+    Part,
+    Role,
+    TaskState,
+    TextPart,
+)
+
+
+class DummyAgentExecutor(AgentExecutor):
+    async def execute(self, context: RequestContext, event_queue: EventQueue):
+        task_updater = TaskUpdater(
+            event_queue, context.task_id, context.context_id
+        )
+        async for i in self._run():
+            parts = [Part(root=TextPart(text=f'Event {i}'))]
+            try:
+                await task_updater.update_status(
+                    TaskState.working,
+                    message=task_updater.new_agent_message(parts),
+                )
+            except RuntimeError:
+                # Stop processing when the event loop is closed
+                break
+
+    async def _run(self):
+        for i in range(1_000_000):  # Simulate a long-running stream
+            yield i
+
+    async def cancel(self, context: RequestContext, event_queue: EventQueue):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_on_message_send_stream():
+    request_handler = DefaultRequestHandler(
+        DummyAgentExecutor(), InMemoryTaskStore()
+    )
+    message_params = MessageSendParams(
+        message=Message(
+            role=Role.user,
+            messageId='msg-123',
+            parts=[Part(root=TextPart(text='How are you?'))],
+        ),
+    )
+
+    async def consume_stream():
+        events = []
+        async for event in request_handler.on_message_send_stream(
+            message_params
+        ):
+            events.append(event)
+            if len(events) >= 3:
+                break  # Stop after a few events
+
+        return events
+
+    # Consume first 3 events from the stream and measure time
+    start = time.perf_counter()
+    events = await consume_stream()
+    elapsed = time.perf_counter() - start
+
+    # Assert we received events quickly
+    assert len(events) == 3
+    assert elapsed < 0.5
+
+    texts = [p.root.text for e in events for p in e.status.message.parts]
+    assert texts == ['Event 0', 'Event 1', 'Event 2']

--- a/tests/server/tasks/test_task_updater.py
+++ b/tests/server/tasks/test_task_updater.py
@@ -1,6 +1,6 @@
 import uuid
 
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -17,216 +17,241 @@ from a2a.types import (
 )
 
 
-class TestTaskUpdater:
-    @pytest.fixture
-    def event_queue(self):
-        """Create a mock event queue for testing."""
-        return Mock(spec=EventQueue)
+@pytest.fixture
+def event_queue():
+    """Create a mock event queue for testing."""
+    return AsyncMock(spec=EventQueue)
 
-    @pytest.fixture
-    def task_updater(self, event_queue):
-        """Create a TaskUpdater instance for testing."""
-        return TaskUpdater(
-            event_queue=event_queue,
-            task_id='test-task-id',
-            context_id='test-context-id',
+
+@pytest.fixture
+def task_updater(event_queue):
+    """Create a TaskUpdater instance for testing."""
+    return TaskUpdater(
+        event_queue=event_queue,
+        task_id='test-task-id',
+        context_id='test-context-id',
+    )
+
+
+@pytest.fixture
+def sample_message():
+    """Create a sample message for testing."""
+    return Message(
+        role=Role.agent,
+        taskId='test-task-id',
+        contextId='test-context-id',
+        messageId='test-message-id',
+        parts=[Part(root=TextPart(text='Test message'))],
+    )
+
+
+@pytest.fixture
+def sample_parts():
+    """Create sample parts for testing."""
+    return [Part(root=TextPart(text='Test part'))]
+
+
+def test_init(event_queue):
+    """Test that TaskUpdater initializes correctly."""
+    task_updater = TaskUpdater(
+        event_queue=event_queue,
+        task_id='test-task-id',
+        context_id='test-context-id',
+    )
+
+    assert task_updater.event_queue == event_queue
+    assert task_updater.task_id == 'test-task-id'
+    assert task_updater.context_id == 'test-context-id'
+
+
+@pytest.mark.asyncio
+async def test_update_status_without_message(task_updater, event_queue):
+    """Test updating status without a message."""
+    await task_updater.update_status(TaskState.working)
+
+    event_queue.enqueue_event.assert_called_once()
+    event = event_queue.enqueue_event.call_args[0][0]
+
+    assert isinstance(event, TaskStatusUpdateEvent)
+    assert event.taskId == 'test-task-id'
+    assert event.contextId == 'test-context-id'
+    assert event.final is False
+    assert event.status.state == TaskState.working
+    assert event.status.message is None
+
+
+@pytest.mark.asyncio
+async def test_update_status_with_message(
+    task_updater, event_queue, sample_message
+):
+    """Test updating status with a message."""
+    await task_updater.update_status(TaskState.working, message=sample_message)
+
+    event_queue.enqueue_event.assert_called_once()
+    event = event_queue.enqueue_event.call_args[0][0]
+
+    assert isinstance(event, TaskStatusUpdateEvent)
+    assert event.taskId == 'test-task-id'
+    assert event.contextId == 'test-context-id'
+    assert event.final is False
+    assert event.status.state == TaskState.working
+    assert event.status.message == sample_message
+
+
+@pytest.mark.asyncio
+async def test_update_status_final(task_updater, event_queue):
+    """Test updating status with final=True."""
+    await task_updater.update_status(TaskState.completed, final=True)
+
+    event_queue.enqueue_event.assert_called_once()
+    event = event_queue.enqueue_event.call_args[0][0]
+
+    assert isinstance(event, TaskStatusUpdateEvent)
+    assert event.final is True
+    assert event.status.state == TaskState.completed
+
+
+@pytest.mark.asyncio
+async def test_add_artifact_with_custom_id_and_name(
+    task_updater, event_queue, sample_parts
+):
+    """Test adding an artifact with a custom ID and name."""
+    await task_updater.add_artifact(
+        parts=sample_parts,
+        artifact_id='custom-artifact-id',
+        name='Custom Artifact',
+    )
+
+    event_queue.enqueue_event.assert_called_once()
+    event = event_queue.enqueue_event.call_args[0][0]
+
+    assert isinstance(event, TaskArtifactUpdateEvent)
+    assert event.artifact.artifactId == 'custom-artifact-id'
+    assert event.artifact.name == 'Custom Artifact'
+    assert event.artifact.parts == sample_parts
+
+
+@pytest.mark.asyncio
+async def test_complete_without_message(task_updater, event_queue):
+    """Test marking a task as completed without a message."""
+    await task_updater.complete()
+
+    event_queue.enqueue_event.assert_called_once()
+    event = event_queue.enqueue_event.call_args[0][0]
+
+    assert isinstance(event, TaskStatusUpdateEvent)
+    assert event.status.state == TaskState.completed
+    assert event.final is True
+    assert event.status.message is None
+
+
+@pytest.mark.asyncio
+async def test_complete_with_message(
+    task_updater, event_queue, sample_message
+):
+    """Test marking a task as completed with a message."""
+    await task_updater.complete(message=sample_message)
+
+    event_queue.enqueue_event.assert_called_once()
+    event = event_queue.enqueue_event.call_args[0][0]
+
+    assert isinstance(event, TaskStatusUpdateEvent)
+    assert event.status.state == TaskState.completed
+    assert event.final is True
+    assert event.status.message == sample_message
+
+
+@pytest.mark.asyncio
+async def test_submit_without_message(task_updater, event_queue):
+    """Test marking a task as submitted without a message."""
+    await task_updater.submit()
+
+    event_queue.enqueue_event.assert_called_once()
+    event = event_queue.enqueue_event.call_args[0][0]
+
+    assert isinstance(event, TaskStatusUpdateEvent)
+    assert event.status.state == TaskState.submitted
+    assert event.final is False
+    assert event.status.message is None
+
+
+@pytest.mark.asyncio
+async def test_submit_with_message(
+    task_updater, event_queue, sample_message
+):
+    """Test marking a task as submitted with a message."""
+    await task_updater.submit(message=sample_message)
+
+    event_queue.enqueue_event.assert_called_once()
+    event = event_queue.enqueue_event.call_args[0][0]
+
+    assert isinstance(event, TaskStatusUpdateEvent)
+    assert event.status.state == TaskState.submitted
+    assert event.final is False
+    assert event.status.message == sample_message
+
+
+@pytest.mark.asyncio
+async def test_start_work_without_message(task_updater, event_queue):
+    """Test marking a task as working without a message."""
+    await task_updater.start_work()
+
+    event_queue.enqueue_event.assert_called_once()
+    event = event_queue.enqueue_event.call_args[0][0]
+
+    assert isinstance(event, TaskStatusUpdateEvent)
+    assert event.status.state == TaskState.working
+    assert event.final is False
+    assert event.status.message is None
+
+
+@pytest.mark.asyncio
+async def test_start_work_with_message(
+    task_updater, event_queue, sample_message
+):
+    """Test marking a task as working with a message."""
+    await task_updater.start_work(message=sample_message)
+
+    event_queue.enqueue_event.assert_called_once()
+    event = event_queue.enqueue_event.call_args[0][0]
+
+    assert isinstance(event, TaskStatusUpdateEvent)
+    assert event.status.state == TaskState.working
+    assert event.final is False
+    assert event.status.message == sample_message
+
+
+def test_new_agent_message(task_updater, sample_parts):
+    """Test creating a new agent message."""
+    with patch(
+        'uuid.uuid4',
+        return_value=uuid.UUID('12345678-1234-5678-1234-567812345678'),
+    ):
+        message = task_updater.new_agent_message(parts=sample_parts)
+
+    assert message.role == Role.agent
+    assert message.taskId == 'test-task-id'
+    assert message.contextId == 'test-context-id'
+    assert message.messageId == '12345678-1234-5678-1234-567812345678'
+    assert message.parts == sample_parts
+    assert message.metadata is None
+
+
+def test_new_agent_message_with_metadata(task_updater, sample_parts):
+    """Test creating a new agent message with metadata and final=True."""
+    metadata = {'key': 'value'}
+
+    with patch(
+        'uuid.uuid4',
+        return_value=uuid.UUID('12345678-1234-5678-1234-567812345678'),
+    ):
+        message = task_updater.new_agent_message(
+            parts=sample_parts, metadata=metadata
         )
 
-    @pytest.fixture
-    def sample_message(self):
-        """Create a sample message for testing."""
-        return Message(
-            role=Role.agent,
-            taskId='test-task-id',
-            contextId='test-context-id',
-            messageId='test-message-id',
-            parts=[Part(root=TextPart(text='Test message'))],
-        )
-
-    @pytest.fixture
-    def sample_parts(self):
-        """Create sample parts for testing."""
-        return [Part(root=TextPart(text='Test part'))]
-
-    def test_init(self, event_queue):
-        """Test that TaskUpdater initializes correctly."""
-        task_updater = TaskUpdater(
-            event_queue=event_queue,
-            task_id='test-task-id',
-            context_id='test-context-id',
-        )
-
-        assert task_updater.event_queue == event_queue
-        assert task_updater.task_id == 'test-task-id'
-        assert task_updater.context_id == 'test-context-id'
-
-    def test_update_status_without_message(self, task_updater, event_queue):
-        """Test updating status without a message."""
-        task_updater.update_status(TaskState.working)
-
-        event_queue.enqueue_event.assert_called_once()
-        event = event_queue.enqueue_event.call_args[0][0]
-
-        assert isinstance(event, TaskStatusUpdateEvent)
-        assert event.taskId == 'test-task-id'
-        assert event.contextId == 'test-context-id'
-        assert event.final is False
-        assert event.status.state == TaskState.working
-        assert event.status.message is None
-
-    def test_update_status_with_message(
-        self, task_updater, event_queue, sample_message
-    ):
-        """Test updating status with a message."""
-        task_updater.update_status(TaskState.working, message=sample_message)
-
-        event_queue.enqueue_event.assert_called_once()
-        event = event_queue.enqueue_event.call_args[0][0]
-
-        assert isinstance(event, TaskStatusUpdateEvent)
-        assert event.taskId == 'test-task-id'
-        assert event.contextId == 'test-context-id'
-        assert event.final is False
-        assert event.status.state == TaskState.working
-        assert event.status.message == sample_message
-
-    def test_update_status_final(self, task_updater, event_queue):
-        """Test updating status with final=True."""
-        task_updater.update_status(TaskState.completed, final=True)
-
-        event_queue.enqueue_event.assert_called_once()
-        event = event_queue.enqueue_event.call_args[0][0]
-
-        assert isinstance(event, TaskStatusUpdateEvent)
-        assert event.final is True
-        assert event.status.state == TaskState.completed
-
-    def test_add_artifact_with_custom_id_and_name(
-        self, task_updater, event_queue, sample_parts
-    ):
-        """Test adding an artifact with a custom ID and name."""
-        task_updater.add_artifact(
-            parts=sample_parts,
-            artifact_id='custom-artifact-id',
-            name='Custom Artifact',
-        )
-
-        event_queue.enqueue_event.assert_called_once()
-        event = event_queue.enqueue_event.call_args[0][0]
-
-        assert isinstance(event, TaskArtifactUpdateEvent)
-        assert event.artifact.artifactId == 'custom-artifact-id'
-        assert event.artifact.name == 'Custom Artifact'
-        assert event.artifact.parts == sample_parts
-
-    def test_complete_without_message(self, task_updater, event_queue):
-        """Test marking a task as completed without a message."""
-        task_updater.complete()
-
-        event_queue.enqueue_event.assert_called_once()
-        event = event_queue.enqueue_event.call_args[0][0]
-
-        assert isinstance(event, TaskStatusUpdateEvent)
-        assert event.status.state == TaskState.completed
-        assert event.final is True
-        assert event.status.message is None
-
-    def test_complete_with_message(
-        self, task_updater, event_queue, sample_message
-    ):
-        """Test marking a task as completed with a message."""
-        task_updater.complete(message=sample_message)
-
-        event_queue.enqueue_event.assert_called_once()
-        event = event_queue.enqueue_event.call_args[0][0]
-
-        assert isinstance(event, TaskStatusUpdateEvent)
-        assert event.status.state == TaskState.completed
-        assert event.final is True
-        assert event.status.message == sample_message
-
-    def test_submit_without_message(self, task_updater, event_queue):
-        """Test marking a task as submitted without a message."""
-        task_updater.submit()
-
-        event_queue.enqueue_event.assert_called_once()
-        event = event_queue.enqueue_event.call_args[0][0]
-
-        assert isinstance(event, TaskStatusUpdateEvent)
-        assert event.status.state == TaskState.submitted
-        assert event.final is False
-        assert event.status.message is None
-
-    def test_submit_with_message(
-        self, task_updater, event_queue, sample_message
-    ):
-        """Test marking a task as submitted with a message."""
-        task_updater.submit(message=sample_message)
-
-        event_queue.enqueue_event.assert_called_once()
-        event = event_queue.enqueue_event.call_args[0][0]
-
-        assert isinstance(event, TaskStatusUpdateEvent)
-        assert event.status.state == TaskState.submitted
-        assert event.final is False
-        assert event.status.message == sample_message
-
-    def test_start_work_without_message(self, task_updater, event_queue):
-        """Test marking a task as working without a message."""
-        task_updater.start_work()
-
-        event_queue.enqueue_event.assert_called_once()
-        event = event_queue.enqueue_event.call_args[0][0]
-
-        assert isinstance(event, TaskStatusUpdateEvent)
-        assert event.status.state == TaskState.working
-        assert event.final is False
-        assert event.status.message is None
-
-    def test_start_work_with_message(
-        self, task_updater, event_queue, sample_message
-    ):
-        """Test marking a task as working with a message."""
-        task_updater.start_work(message=sample_message)
-
-        event_queue.enqueue_event.assert_called_once()
-        event = event_queue.enqueue_event.call_args[0][0]
-
-        assert isinstance(event, TaskStatusUpdateEvent)
-        assert event.status.state == TaskState.working
-        assert event.final is False
-        assert event.status.message == sample_message
-
-    def test_new_agent_message(self, task_updater, sample_parts):
-        """Test creating a new agent message."""
-        with patch(
-            'uuid.uuid4',
-            return_value=uuid.UUID('12345678-1234-5678-1234-567812345678'),
-        ):
-            message = task_updater.new_agent_message(parts=sample_parts)
-
-        assert message.role == Role.agent
-        assert message.taskId == 'test-task-id'
-        assert message.contextId == 'test-context-id'
-        assert message.messageId == '12345678-1234-5678-1234-567812345678'
-        assert message.parts == sample_parts
-        assert message.metadata is None
-
-    def test_new_agent_message_with_metadata(self, task_updater, sample_parts):
-        """Test creating a new agent message with metadata and final=True."""
-        metadata = {'key': 'value'}
-
-        with patch(
-            'uuid.uuid4',
-            return_value=uuid.UUID('12345678-1234-5678-1234-567812345678'),
-        ):
-            message = task_updater.new_agent_message(
-                parts=sample_parts, metadata=metadata
-            )
-
-        assert message.role == Role.agent
-        assert message.taskId == 'test-task-id'
-        assert message.contextId == 'test-context-id'
-        assert message.messageId == '12345678-1234-5678-1234-567812345678'
-        assert message.parts == sample_parts
-        assert message.metadata == metadata
+    assert message.role == Role.agent
+    assert message.taskId == 'test-task-id'
+    assert message.contextId == 'test-context-id'
+    assert message.messageId == '12345678-1234-5678-1234-567812345678'
+    assert message.parts == sample_parts
+    assert message.metadata == metadata


### PR DESCRIPTION
# Description

Fixes #111 🦕

> [!WARNING]  
> Backwards incompatible change, as `EventQueue.enqueue_event()` becomes async.

The implementation of the `AgentExecutor` usually looks like this:
```
class SomeAgentExecutor(AgentExecutor):

    async def execute(self, context: RequestContext, event_queue: EventQueue) -> None:
        task_updater = TaskUpdater(event_queue, context.task_id, context.context_id)
        task_updater.start_work()
        
        async for event in self._run_async(...):
            if event.is_final_response():
                task_updater.add_artifact(parts)
                task_updater.complete()
                break
            task_updater.update_status(
                TaskState.working,
                message=task_updater.new_agent_message(parts),
            )
```

The issue is that the loop inside `execute()` calls `task_updater.update_status()` synchronously.
If `update_status` is not an async function, then the `execute()` method does not yield control back to the event loop during each iteration. That’s why everything gets blocked until the loop finishes.

So the first step is to make sure that `update_status()` and `event_queue.enqueue_event()` are async functions.
Still, this is not enough, since `EventQueue` uses `put_nowait()`, so it never actually suspends.
So the 2nd step is to switch from `queue.put_nowait()` to `queue.put()`.

This is still not enough. 
By default, an `asyncio.Queue` is unbounded , so `queue.put` never actually suspends the producer.
Therefore, the producer loop in `SomeAgentExecutor` still runs full-speed without yielding.
So the 3rd step is to make the queue bounded. I have set the size to 1024, but it can be actually lower or higher if needed.
