### PR TITLE
fix: Event consumer should stop on input_required

### DIFF
--- a/src/a2a/server/events/event_consumer.py
+++ b/src/a2a/server/events/event_consumer.py
@@ -112,6 +112,7 @@ class EventConsumer:
                             TaskState.failed,
                             TaskState.rejected,
                             TaskState.unknown,
+                            TaskState.input_required
                         )
                     )
                 )


### PR DESCRIPTION
Event consumer currently only stops properly for streaming events. But for sync calls that transition to input_required state, the consumer doesn't treat them as final events and results in queue closed exception.

Example test:
```py
task: Task= new_task(context.message)
result = await self.agent.invoke()
message = new_agent_text_message(result)
task.status = TaskStatus(state=TaskState.input_required, message=message)
event_queue.enqueue_event(task)
```