### PR TITLE
refactor!: Make the FastAPI dependency optional

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ authors = [{ name = "Google LLC", email = "googleapis-packages@google.com" }]
 requires-python = ">=3.10"
 keywords = ["A2A", "A2A SDK", "A2A Protocol", "Agent2Agent"]
 dependencies = [
-    "fastapi>=0.115.2",
     "httpx>=0.28.1",
     "httpx-sse>=0.4.0",
     "google-api-core>=1.26.0",
@@ -80,6 +79,10 @@ dev = [
     "uv-dynamic-versioning>=0.8.2",
     "types-protobuf",
     "types-requests",
+    "fastapi>=0.115.2",
+]
+fastapi = [
+    "fastapi>=0.115.2",
 ]
 
 [[tool.uv.index]]

--- a/src/a2a/server/apps/jsonrpc/fastapi_app.py
+++ b/src/a2a/server/apps/jsonrpc/fastapi_app.py
@@ -2,8 +2,11 @@ import logging
 
 from typing import Any
 
-from fastapi import FastAPI, Request, Response
-
+from a2a.server.apps.jsonrpc.fastapi_import_helpers import (
+    FastAPI,
+    Request,
+    Response,
+)
 from a2a.server.apps.jsonrpc.jsonrpc_app import (
     CallContextBuilder,
     JSONRPCApplication,

--- a/src/a2a/server/apps/jsonrpc/fastapi_import_helpers.py
+++ b/src/a2a/server/apps/jsonrpc/fastapi_import_helpers.py
@@ -1,0 +1,32 @@
+"""Helper functions for handling optional FastAPI package imports."""
+
+try:
+    from fastapi import FastAPI, Request, Response
+except ImportError:
+    _FASTAPI_DEPENDENCY_ERROR_MSG = """
+    The A2A Python SDK FastAPI app requires the FastAPI package, which
+    is an optional dependency. To fix this issue, please add the fastapi
+    package to your project, e.g. by executing
+
+        uv add fastapi
+
+    or install the A2A SDK with the optional FastAPI dependency:
+
+        uv add a2a-sdk[fastapi]
+    """
+
+    class _DummyFastAPIClasses:
+        """Parent class for dummy fastapi.* class declarations."""
+
+        def __init__(self) -> None:
+            """Raises ImportError when initiating a dummy fastapi.* instance."""
+            raise ImportError(_FASTAPI_DEPENDENCY_ERROR_MSG)
+
+    class FastAPI(_DummyFastAPIClasses):
+        """A dummy fastapi.FastAPI declaration."""
+
+    class Request(_DummyFastAPIClasses):
+        """A dummy fastapi.Request declaration."""
+
+    class Response(_DummyFastAPIClasses):
+        """A dummy fastapi.Response declaration."""

--- a/src/a2a/server/apps/jsonrpc/jsonrpc_app.py
+++ b/src/a2a/server/apps/jsonrpc/jsonrpc_app.py
@@ -7,7 +7,6 @@ from abc import ABC, abstractmethod
 from collections.abc import AsyncGenerator
 from typing import Any
 
-from fastapi import FastAPI
 from pydantic import ValidationError
 from sse_starlette.sse import EventSourceResponse
 from starlette.applications import Starlette
@@ -17,6 +16,7 @@ from starlette.responses import JSONResponse, Response
 
 from a2a.auth.user import UnauthenticatedUser
 from a2a.auth.user import User as A2AUser
+from a2a.server.apps.jsonrpc.fastapi_import_helpers import FastAPI
 from a2a.server.context import ServerCallContext
 from a2a.server.request_handlers.jsonrpc_handler import JSONRPCHandler
 from a2a.server.request_handlers.request_handler import RequestHandler

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,6 @@ resolution-markers = [
 name = "a2a-sdk"
 source = { editable = "." }
 dependencies = [
-    { name = "fastapi" },
     { name = "google-api-core" },
     { name = "grpcio" },
     { name = "grpcio-reflection" },
@@ -28,6 +27,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "datamodel-code-generator" },
+    { name = "fastapi" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -38,10 +38,12 @@ dev = [
     { name = "types-requests" },
     { name = "uv-dynamic-versioning" },
 ]
+fastapi = [
+    { name = "fastapi" },
+]
 
 [package.metadata]
 requires-dist = [
-    { name = "fastapi", specifier = ">=0.115.2" },
     { name = "google-api-core", specifier = ">=1.26.0" },
     { name = "grpcio", specifier = ">=1.60" },
     { name = "grpcio-reflection", specifier = ">=1.7.0" },
@@ -59,6 +61,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "datamodel-code-generator", specifier = ">=0.30.0" },
+    { name = "fastapi", specifier = ">=0.115.2" },
     { name = "mypy", specifier = ">=1.15.0" },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-asyncio", specifier = ">=0.26.0" },
@@ -69,6 +72,7 @@ dev = [
     { name = "types-requests" },
     { name = "uv-dynamic-versioning", specifier = ">=0.8.2" },
 ]
+fastapi = [{ name = "fastapi", specifier = ">=0.115.2" }]
 
 [[package]]
 name = "annotated-types"


### PR DESCRIPTION
# Description

With this update, using A2AFastAPIApplication requires either adding the FastAPI package directly to the project or indicating the "fastapi" group when installing a2a-sdk, e.g., with uv "uv add a2a-sdk[fastapi]" or with pip "pip install a2a-sdk[fastapi]"

## Additional Checks

- Verified that the "helloworld" agent sample works with this change.
- Verified that a reasonable error message is printed when trying to use `A2AFastAPIApplication`.

---

Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/google-a2a/a2a-python/blob/main/CONTRIBUTING.md).
- [x] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
  - Important Prefixes for [release-please](https://github.com/googleapis/release-please):
    - `fix:` which represents bug fixes, and correlates to a [SemVer](https://semver.org/) patch.
    - `feat:` represents a new feature, and correlates to a SemVer minor.
    - `feat!:`, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the `!`) and will result in a SemVer major.
- [x] Ensure the tests and linter pass (Run `nox -s format` from the repository root to format)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
