### PR TITLE
fix: send notifications on message not streaming

### DIFF
--- a/src/a2a/server/request_handlers/default_request_handler.py
+++ b/src/a2a/server/request_handlers/default_request_handler.py
@@ -55,6 +55,7 @@ TERMINAL_TASK_STATES = {
     TaskState.rejected,
 }
 
+
 @trace_class(kind=SpanKind.SERVER)
 class DefaultRequestHandler(RequestHandler):
     """Default request handler for all incoming requests.
@@ -248,6 +249,11 @@ class DefaultRequestHandler(RequestHandler):
                 raise ServerError(
                     InternalError(message='Task ID mismatch in agent response')
                 )
+
+            if self._push_notifier and task_id:
+                latest_task = await result_aggregator.current_result
+                if isinstance(latest_task, Task):
+                    await self._push_notifier.send_notification(latest_task)
 
         finally:
             if interrupted:


### PR DESCRIPTION
# Description

The proposed fix, if the team does want push notifications to be supported in a non-streaming setup

Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [ ] Follow the [`CONTRIBUTING` Guide](https://github.com/google-a2a/a2a-python/blob/main/CONTRIBUTING.md).
- [ ] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
  - Important Prefixes for [release-please](https://github.com/googleapis/release-please):
    - `fix:` which represents bug fixes, and correlates to a [SemVer](https://semver.org/) patch.
    - `feat:` represents a new feature, and correlates to a SemVer minor.
    - `feat!:`, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the `!`) and will result in a SemVer major.
- [ ] Ensure the tests and linter pass (Run `nox -s format` from the repository root to format)
- [ ] Appropriate docs were updated (if necessary)

Fixes #218 
