### PR TITLE
fix: Resolve `APIKeySecurityScheme` parsing failed

### DIFF
--- a/src/a2a/server/apps/jsonrpc/jsonrpc_app.py
+++ b/src/a2a/server/apps/jsonrpc/jsonrpc_app.py
@@ -375,7 +375,11 @@ class JSONRPCApplication(ABC):
         # The public agent card is a direct serialization of the agent_card
         # provided at initialization.
         return JSONResponse(
-            self.agent_card.model_dump(mode='json', exclude_none=True)
+            self.agent_card.model_dump(
+                mode='json',
+                exclude_none=True,
+                by_alias=True,
+            )
         )
 
     async def _handle_get_authenticated_extended_agent_card(
@@ -392,7 +396,9 @@ class JSONRPCApplication(ABC):
         if self.extended_agent_card:
             return JSONResponse(
                 self.extended_agent_card.model_dump(
-                    mode='json', exclude_none=True
+                    mode='json',
+                    exclude_none=True,
+                    by_alias=True,
                 )
             )
         # If supportsAuthenticatedExtendedCard is true, but no specific


### PR DESCRIPTION
Fixes #220

- Adds `by_alias=True` parameter when using `model_dump()` for `AgentCard` and `ExtendedAgentCard` 
